### PR TITLE
Feature/oauth/#8 login request

### DIFF
--- a/backend/src/main/java/codesquad/team01/issuetracker/IssueTrackerApplication.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/IssueTrackerApplication.java
@@ -1,8 +1,11 @@
 package codesquad.team01.issuetracker;
 
+import codesquad.team01.issuetracker.common.config.GithubOAuthProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
+@EnableConfigurationProperties(GithubOAuthProperties.class)
 @SpringBootApplication
 public class IssueTrackerApplication {
 

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/api/AuthController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/api/AuthController.java
@@ -20,12 +20,14 @@ public class AuthController {
     private final AuthService authService;
     private final AuthorizationUrlBuilder authorizationUrlBuilder;
 
+    // Authorization endpoint
     @GetMapping("/api/v1/oauth/github/login")
     public void redirectToGithub(HttpServletResponse response, HttpSession session) throws IOException {
         URI githubUri = authorizationUrlBuilder.buildAuthorizeUri(session);
         response.sendRedirect(githubUri.toString());
     }
 
+    // Redirect(Callback) endpoint
     @GetMapping("/api/v1/oauth/callback")
     public LoginResponse githubCallback(
             @RequestParam("code") String code,

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/api/AuthController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/api/AuthController.java
@@ -1,4 +1,24 @@
 package codesquad.team01.issuetracker.auth.api;
 
+import codesquad.team01.issuetracker.auth.util.AuthorizationUrlBuilder;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
 public class AuthController {
+
+    private final AuthorizationUrlBuilder authorizationUrlBuilder;
+
+    @GetMapping("/api/v1/oauth/github/login")
+    public void redirectToGithub(HttpServletResponse response, HttpSession session) throws IOException {
+        URI githubUri = authorizationUrlBuilder.buildAuthorizeUri(session);
+        response.sendRedirect(githubUri.toString());
+    }
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/api/AuthController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/api/AuthController.java
@@ -1,10 +1,13 @@
 package codesquad.team01.issuetracker.auth.api;
 
+import codesquad.team01.issuetracker.auth.dto.LoginResponse;
+import codesquad.team01.issuetracker.auth.service.AuthService;
 import codesquad.team01.issuetracker.auth.util.AuthorizationUrlBuilder;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
@@ -14,11 +17,26 @@ import java.net.URI;
 @RequiredArgsConstructor
 public class AuthController {
 
+    private final AuthService authService;
     private final AuthorizationUrlBuilder authorizationUrlBuilder;
 
     @GetMapping("/api/v1/oauth/github/login")
     public void redirectToGithub(HttpServletResponse response, HttpSession session) throws IOException {
         URI githubUri = authorizationUrlBuilder.buildAuthorizeUri(session);
         response.sendRedirect(githubUri.toString());
+    }
+
+    @GetMapping("/api/v1/oauth/callback")
+    public LoginResponse githubCallback(
+            @RequestParam("code") String code,
+            @RequestParam("state") String state,
+            HttpSession session) {
+        String savedState = (String) session.getAttribute("oauth_state");
+        if (savedState == null || !savedState.equals(state)) {
+            throw new IllegalStateException("유효하지 않은 state");
+        }
+        session.removeAttribute("oauth_state");
+
+        return authService.loginWithGitHub(code);
     }
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/dto/LoginResponse.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/dto/LoginResponse.java
@@ -1,4 +1,8 @@
 package codesquad.team01.issuetracker.auth.dto;
 
-public class LoginResponse {
+public record LoginResponse(
+        Long id,
+        String loginId,
+        String avatarUrl
+) {
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/service/AuthService.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/service/AuthService.java
@@ -20,13 +20,24 @@ public class AuthService {
     private final GithubOAuthProperties properties;
     private final RestTemplate restTemplate;
 
+    public final String CLIENT_ID = "client_id";
+    public final String CLIENT_SECRET = "client_secret";
+    public final String AUTHORIZATION_CODE = "code";
+    public final String REDIRECT_URI = "redirect_uri";
+    public final String ID = "id";
+    public final String LOGIN = "login";
+    public final String AVATAR_URL = "avatar_url";
+    public final String GITHUB = "github";
+    public final String ACCESS_TOKEN = "access_token";
+
+    // 깃헙에서 받은 authorization code 받은 후 access token 요청하고 사용자 정보 요청
     public LoginResponse loginWithGitHub(String code) {
-        // access token 요청
+        // 깃헙에 access token 요청
         Map<String, String> tokenRequest = Map.of(
-                "client_id", properties.getClientId(),
-                "client_secret", properties.getClientSecret(),
-                "code", code,
-                "redirect_uri", properties.getRedirectUri()
+                CLIENT_ID, properties.getClientId(),
+                CLIENT_SECRET, properties.getClientSecret(),
+                AUTHORIZATION_CODE, code,
+                REDIRECT_URI, properties.getRedirectUri()
         );
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
@@ -35,31 +46,31 @@ public class AuthService {
         ResponseEntity<Map> tokenResponse = restTemplate.postForEntity(
                 properties.getTokenUri(), request, Map.class
         );
-        String accessToken = (String) tokenResponse.getBody().get("access_token");
+        String accessToken = (String) tokenResponse.getBody().get(ACCESS_TOKEN);
 
         // 사용자 정보 요청
         HttpHeaders authHeaders = new HttpHeaders();
         authHeaders.setBearerAuth((accessToken));
         HttpEntity<Void> userRequest = new HttpEntity<>(authHeaders);
 
-        ResponseEntity<Map> userResponse = restTemplate.exchange(   // ?
+        ResponseEntity<Map> userResponse = restTemplate.exchange(
                 properties.getUserInfoUri(), HttpMethod.GET, userRequest, Map.class
         );
         Map<String, Object> userMap = userResponse.getBody();
-        Long githubId = ((Number) userMap.get("id")).longValue();   // ?
-        String loginId = (String) userMap.get("login");
-        String avatarUrl = (String) userMap.get("avatar_url");
+        Long githubId = ((Number) userMap.get(ID)).longValue();
+        String loginId = (String) userMap.get(LOGIN);
+        String avatarUrl = (String) userMap.get(AVATAR_URL);
 
-        // 사용자 저장 혹은 업데이트
+        // 사용자 저장(회원가입) 혹은 업데이트
         User user = userRepository.findByLoginId(loginId)
                 .orElseGet(() -> userRepository.save(
-                        User.builder()
-                                .loginId(loginId)
-                                .providerId(String.valueOf(githubId))
-                                .authProvider("github")
-                                .username(loginId)
-                                .email(null)
-                                .build()
+                                User.builder()
+                                        .loginId(loginId)
+                                        .providerId(String.valueOf(githubId))
+                                        .authProvider(GITHUB)
+                                        .username(loginId)
+                                        .email(null)
+                                        .build()
                         )
                 );
 

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/service/AuthService.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/service/AuthService.java
@@ -1,4 +1,73 @@
 package codesquad.team01.issuetracker.auth.service;
 
+import codesquad.team01.issuetracker.auth.domain.User;
+import codesquad.team01.issuetracker.auth.dto.LoginResponse;
+import codesquad.team01.issuetracker.auth.repository.UserRepository;
+import codesquad.team01.issuetracker.common.config.GithubOAuthProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
 public class AuthService {
+
+    private final UserRepository userRepository;
+    private final GithubOAuthProperties properties;
+    private final RestTemplate restTemplate;
+
+    public LoginResponse loginWithGitHub(String code) {
+        // access token 요청
+        Map<String, String> tokenRequest = Map.of(
+                "client_id", properties.getClientId(),
+                "client_secret", properties.getClientSecret(),
+                "code", code,
+                "redirect_uri", properties.getRedirectUri()
+        );
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        HttpEntity<Map<String, String>> request = new HttpEntity<>(tokenRequest, headers);
+
+        ResponseEntity<Map> tokenResponse = restTemplate.postForEntity(
+                properties.getTokenUri(), request, Map.class
+        );
+        String accessToken = (String) tokenResponse.getBody().get("access_token");
+
+        // 사용자 정보 요청
+        HttpHeaders authHeaders = new HttpHeaders();
+        authHeaders.setBearerAuth((accessToken));
+        HttpEntity<Void> userRequest = new HttpEntity<>(authHeaders);
+
+        ResponseEntity<Map> userResponse = restTemplate.exchange(   // ?
+                properties.getUserInfoUri(), HttpMethod.GET, userRequest, Map.class
+        );
+        Map<String, Object> userMap = userResponse.getBody();
+        Long githubId = ((Number) userMap.get("id")).longValue();   // ?
+        String loginId = (String) userMap.get("login");
+        String avatarUrl = (String) userMap.get("avatar_url");
+
+        // 사용자 저장 혹은 업데이트
+        User user = userRepository.findByLoginId(loginId)
+                .orElseGet(() -> userRepository.save(
+                        User.builder()
+                                .loginId(loginId)
+                                .providerId(String.valueOf(githubId))
+                                .authProvider("github")
+                                .username(loginId)
+                                .email(null)
+                                .build()
+                        )
+                );
+
+        // 로그인 응답 생성
+        return new LoginResponse(
+                user.getId(),
+                user.getLoginId(),
+                avatarUrl
+        );
+    }
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/util/AuthorizationUrlBuilder.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/util/AuthorizationUrlBuilder.java
@@ -15,6 +15,7 @@ public class AuthorizationUrlBuilder {
 
     private final GithubOAuthProperties properties;
 
+    // 인증을 위한 uri 조립 후 반환
     public URI buildAuthorizeUri(HttpSession session) {
         // 랜덤값으로 state 생성 후 세션에 넣음
         String state = UUID.randomUUID().toString();

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/util/AuthorizationUrlBuilder.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/util/AuthorizationUrlBuilder.java
@@ -1,0 +1,32 @@
+package codesquad.team01.issuetracker.auth.util;
+
+import codesquad.team01.issuetracker.common.config.GithubOAuthProperties;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class AuthorizationUrlBuilder {
+
+    private final GithubOAuthProperties properties;
+
+    public URI buildAuthorizeUri(HttpSession session) {
+        // 랜덤값으로 state 생성 후 세션에 넣음
+        String state = UUID.randomUUID().toString();
+        session.setAttribute("oauth_state", state);
+
+        return UriComponentsBuilder
+                .fromUriString(properties.getAuthorizeUri())
+                .queryParam("client_id", properties.getClientId())
+                .queryParam("redirect_uri", properties.getRedirectUri())
+                .queryParam("scope", properties.getScope())
+                .queryParam("state", state)
+                .build()
+                .toUri();
+    }
+}

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/config/GithubOAuthProperties.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/config/GithubOAuthProperties.java
@@ -4,7 +4,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-// application.yaml 의 github.oauth 아래에 정의된 모든 프로퍼티를 이 클래스의 필드와 자동으로 매핑해준다
+// application.yaml 의 github.oauth 아래에 정의된 모든 프로퍼티를 이 클래스의 필드와 자동으로 매핑
 @Data
 @NoArgsConstructor
 @ConfigurationProperties(prefix = "github.oauth")

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/config/GithubOAuthProperties.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/config/GithubOAuthProperties.java
@@ -1,0 +1,19 @@
+package codesquad.team01.issuetracker.common.config;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+// application.yaml 의 github.oauth 아래에 정의된 모든 프로퍼티를 이 클래스의 필드와 자동으로 매핑해준다
+@Data
+@NoArgsConstructor
+@ConfigurationProperties(prefix = "github.oauth")
+public class GithubOAuthProperties {
+    private String clientId;
+    private String clientSecret;
+    private String authorizeUri;
+    private String tokenUri;
+    private String userInfoUri;
+    private String redirectUri;
+    private String scope;
+}

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/config/RestTemplateConfig.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package codesquad.team01.issuetracker.common.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}


### PR DESCRIPTION
1. 작업 내용 : OAuth 인증을 사용한 로그인 혹은 회원가입 구현 (깃헙)

- GitHub OAuth App에서 발급받은 clientId/clientSecret 및 엔드포인트 URL을 application.yml에 커스텀 프로퍼티(github.oauth)로 등록했습니다.
- @ConfigurationProperties로 바인딩할 GithubOAuthProperties 클래스를 작성했습니다.
- RestTemplate 빈 등록을 위한 RestTemplateConfig 추가했습니다.
- AuthorizationUrlBuilder 유틸 클래스 구현했습니다.
- AuthController에 두 개의 엔드포인트 추가했습니다.
- AuthService.loginWithGitHub(code) 메서드 구현했습니다.
- DTO(LoginResponse)를 record 형태로 간결하게 정의해 뒀습니다.

그림은 OAuth 인증 구현 흐름입니다.

![image](https://github.com/user-attachments/assets/90445728-5a76-4bc0-8748-2677a88e9f07)

<br>

2. 작업 진행 방식

- Lombok 활용으로 보일러플레이트 최소화했습니다. (@RequiredArgsConstructor, @Data, record)
- 프로퍼티 관리: YAML → @ConfigurationProperties 바인딩으로 타입 안전성을 확보했습니다.
- DI/빈 설정: Spring @Configuration + @Bean → RestTemplate 재사용했습니다.

<br>

3. 테스트 작업 방식

- 터미널에서 curl -I --max-redirs 0 http://localhost:8080/api/v1/oauth/github/login 으로 302 응답·Location을 확인했습니다.
- 브라우저에서 /login → GitHub 인증 페이지 → /callback?code&state 콜백 동작을 확인했습니다.

<br>

4. 배포 방식

- EC2 배포(예정) : EC2에 사용자 그룹 생성해서 팀원들 계정을 준비해뒀습니다.

<br>

5. 지난 주에 비해 잘한 점, 부족한 점

- 도메인 기준으로 일감 나누고 작업 속도가 많이 향상되었습니다.
- OAuth 흐름 전반(로그인 시작 → 토큰 교환 → 유저 저장) 기능을 처음부터 끝까지 직접 구현했습니다.
- 세션 기반 CSRF 방어(state) 로직을 추가했습니다.
- 배포는 하지 못했습니다.
- 예외 상황 핸들링 로직을 구현하지 못했습니다.

<br>

6. 앞으로 진행할 작업

- 예외별 @ControllerAdvice 기반으로 통합 에러 핸들링 로직을 구현할 계획입니다.

